### PR TITLE
Fix form reset bug in Firefox

### DIFF
--- a/graph_explorer/graph_explorer/templates/index.html
+++ b/graph_explorer/graph_explorer/templates/index.html
@@ -73,7 +73,7 @@
           <p class="panel-heading">Visualizer</p>
           <div class="panel-block">
             <div class="select">
-              <select id="visualizer-select" onchange="selectVisualizer(this.value)">
+              <select id="visualizer-select" onchange="selectVisualizer(this.value)" autocomplete="off">
                 {% for visualizer in visualizers %}
                   <option 
                     value="{{ visualizer.identifier }}" 
@@ -107,7 +107,7 @@
 
           <div class="panel-block">
             {% if active_ws_id != -1 %}
-            <form id="filter-form" action="{% url 'filter' %}" class="filter-form">
+            <form id="filter-form" action="{% url 'filter' %}" class="filter-form" autocomplete="off">
               {% csrf_token %}
               <input name="attribute" id="filter-attribute-input" class="input" type="text" placeholder="Attribute" />
               <div class="select">


### PR DESCRIPTION
Filter form was not correctly resetting due to browser form caching/autocomplete mechanism. 
The issue was only present in Firefox browser.

It is solved by adding `autocomplete="off"` on form and input elements where needed.